### PR TITLE
Hs300 toggle fix

### DIFF
--- a/tplinkcloud/device.py
+++ b/tplinkcloud/device.py
@@ -54,6 +54,7 @@ class TPLinkDevice:
 
     def power_off(self):
         if self.child_id:
+            return self._pass_through_request('system', 'set_relay_state', { 'state': 0 })
         return self._pass_through_request('system', 'set_relay_state', 0)
 
     def toggle(self):

--- a/tplinkcloud/device.py
+++ b/tplinkcloud/device.py
@@ -48,9 +48,12 @@ class TPLinkDevice:
         return sub_request_response
 
     def power_on(self):
+        if self.child_id:
+            return self._pass_through_request('system', 'set_relay_state', { 'state': 1 })
         return self._pass_through_request('system', 'set_relay_state', 1)
 
     def power_off(self):
+        if self.child_id:
         return self._pass_through_request('system', 'set_relay_state', 0)
 
     def toggle(self):


### PR DESCRIPTION
The request to toggle an HS300 plug required an extra parameter in the request. The previous implementation would hang for a long time, then cause the entire device to turn off/on

Now, the individual plugs are addressable for power on/off