### PR TITLE
 Adding support for HS110 devices

### DIFF
--- a/tplinkcloud/device_manager.py
+++ b/tplinkcloud/device_manager.py
@@ -3,8 +3,9 @@ from .device_client import TPLinkDeviceClient
 from .client import TPLinkApi
 
 # Supported devices
-from .hs300 import HS300
 from .hs100 import HS100
+from .hs110 import HS110
+from .hs300 import HS300
 from .device import TPLinkDevice
 
 class TPLinkDeviceManager:
@@ -49,9 +50,11 @@ class TPLinkDeviceManager:
             self._auth_token,
             verbose=self._verbose
         )
-        if tplink_device_info.device_model.startswith('HS300'):
+        if tplink_device_info.device_model.startswith('HS100'):
             return HS100(client, tplink_device_info.device_id, tplink_device_info)
-        elif tplink_device_info.device_model.startswith('HS100'):
+        elif tplink_device_info.device_model.startswith('HS110'):
+            return HS110(client, tplink_device_info.device_id, tplink_device_info)
+        elif tplink_device_info.device_model.startswith('HS300'):
             return HS300(client, tplink_device_info.device_id, tplink_device_info)
         else:
             return TPLinkDevice(client, tplink_device_info.device_id, tplink_device_info)

--- a/tplinkcloud/device_type.py
+++ b/tplinkcloud/device_type.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 class TPLinkDeviceType(Enum):
     HS100 = 100
+    HS110 = 110
     HS300 = 300
     HS300CHILD = 301
     UNKNOWN = 9999

--- a/tplinkcloud/hs110.py
+++ b/tplinkcloud/hs110.py
@@ -1,0 +1,13 @@
+from .device_type import TPLinkDeviceType
+from .hs100 import HS100, HS100SysInfo
+
+class HS110SysInfo(HS100SysInfo):
+
+    def __init__(self, sys_info):
+        super().__init__(sys_info)
+
+class HS110(HS100):
+
+    def __init__(self, client, device_id, device_info):
+        super().__init__(client, device_id, device_info)
+        self.model_type = TPLinkDeviceType.HS110


### PR DESCRIPTION
It is assumed they have the same sys info as an HS100.

This also fixes a bug introduced in a previous commit where the HS300
device was being constructed as an HS100 and vice versa