### PR TITLE
Defining emeter power types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '0.2.0'
+__version__ = '1.0.0'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tplinkcloud/emeter_device.py
+++ b/tplinkcloud/emeter_device.py
@@ -1,15 +1,41 @@
 from .device import TPLinkDevice
 
+class CurrentPower:
+
+    def __init__(self, realtime_data):
+        self.voltage_mv = realtime_data.get('voltage_mv')
+        self.current_ma = realtime_data.get('current_ma')
+        self.power_mw = realtime_data.get('power_mw')
+        self.total_wh = realtime_data.get('total_wh')
+    
+class DayPowerSummary:
+
+    def __init__(self, day_data):
+        self.year = day_data.get('year')
+        self.month = day_data.get('month')
+        self.day = day_data.get('day')
+        self.energy_wh = day_data.get('energy_wh')
+
+class MonthPowerSummary:
+
+    def __init__(self, day_data):
+        self.year = day_data.get('year')
+        self.month = day_data.get('month')
+        self.energy_wh = day_data.get('energy_wh')
+
 class TPLinkEMeterDevice(TPLinkDevice):
 
     def __init__(self, client, device_id, device_info, child_id=None):
         super().__init__(client, device_id, device_info, child_id)
 
     def get_power_usage_realtime(self):
-        return self._pass_through_request('emeter', 'get_realtime', None)
+        realtime_data = self._pass_through_request('emeter', 'get_realtime', None)
+        if realtime_data['err_code'] == 0:
+            return CurrentPower(realtime_data)
+        return None
     
     def get_power_usage_day(self, year, month):
-        return self._pass_through_request(
+        day_response_data = self._pass_through_request(
             'emeter', 
             'get_daystat', 
             { 
@@ -17,12 +43,19 @@ class TPLinkEMeterDevice(TPLinkDevice):
                 'month': month
             }
         )
+        if day_response_data['err_code'] == 0:
+            return [DayPowerSummary(day_data) for day_data in day_response_data['day_list']]
+        return []
+
 
     def get_power_usage_month(self, year):
-        return self._pass_through_request(
+        month_response_data = self._pass_through_request(
             'emeter',
             'get_monthstat',
             { 
                 'year': year
             }
         )
+        if month_response_data['err_code'] == 0:
+            return [MonthPowerSummary(month_data) for month_data in month_response_data['month_list']]
+        return []


### PR DESCRIPTION
These types are intended to provide "dot accessible" structure to the EMeter device readings

This includes a bump to version 1.0.0 as the changes are not backwards compatible with previous uses of EMeter device power data.