### PR TITLE
Add HS300 None checks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tplinkcloud/hs300.py
+++ b/tplinkcloud/hs300.py
@@ -34,9 +34,10 @@ class HS300(TPLinkEMeterDevice):
     def get_children(self):
         sys_info = self.get_sys_info()
         children = []
-        for child_info in sys_info.children:
-            device_child = HS300Child(self.client, sys_info.device_id, child_info.id, child_info)
-            children.append(device_child)
+        if sys_info:
+            for child_info in sys_info.children:
+                device_child = HS300Child(self.client, sys_info.device_id, child_info.id, child_info)
+                children.append(device_child)
         return children
 
     # An override of an identified TPLinkDevice
@@ -45,4 +46,6 @@ class HS300(TPLinkEMeterDevice):
 
     def get_sys_info(self):
         sys_info = self._get_sys_info()
-        return HS300SysInfo(sys_info)
+        if sys_info:
+            return HS300SysInfo(sys_info)
+        return None


### PR DESCRIPTION
Found a bug breaking initialization because one of the HS300 devices was mis-reporting. Since we "prefetch" all devices, it broke all requests using the device manager.