### PR TITLE
Add support for KP303 Power Strips

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The following devices are _officially_ supported by the library at this time:
 * HS105 (Smaller Single-Socket Smart Plug - 15 Amp)
 * HS110 (Older Smart Plug - Blocks two outlets as a single outlet)
 * KP115 (Small Single-Socket Smart Plug - 15 Amp; replacement for HS110)
+* KP303 (Smart Plug Power Strip with 3 Outlets)
 
 # Installation
 
@@ -69,7 +70,7 @@ if devices:
 
 ## Control your devices
 
-### Smart Power Strips (HS300)
+### Smart Power Strips (HS300, KP303)
 
 Toggle a plug:
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.0.0'
+__version__ = '2.1.0'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tplinkcloud/device_manager.py
+++ b/tplinkcloud/device_manager.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from .device_info import TPLinkDeviceInfo
 from .device_client import TPLinkDeviceClient
 from .client import TPLinkApi
@@ -38,25 +36,21 @@ class TPLinkDeviceManager:
         self._auth_token = self._tplink_api.login(username, password)
         # Fetch the devices up front if prefetch and cache them if caching
         if prefetch and self._cache_devices:
-            asyncio.run(self._fetch_devices())
+            self._fetch_devices()
 
-    async def _fetch_devices(self):
+    def _fetch_devices(self):
         if self._cached_devices:
             return self._cached_devices
 
         device_info_list = self._tplink_api.get_device_info_list(
             self._auth_token)
 
-        devices = await asyncio.gather(
-            *[self._construct_device(device_info) for device_info in device_info_list]
-        )
-
-        child_devices = await asyncio.gather(
-            *[device.get_children() for device in devices if device.has_children()]
-        )
-
-        for child_groups in child_devices:
-            devices.extend(child_groups)
+        devices = []
+        for device_info in device_info_list:
+            device = self._construct_device(device_info)
+            devices.append(device)
+            if device.has_children():
+                devices.extend(device.get_children())
 
         if self._cache_devices:
             self._device_info_list = device_info_list
@@ -64,7 +58,7 @@ class TPLinkDeviceManager:
 
         return devices
 
-    async def _construct_device(self, device_info):
+    def _construct_device(self, device_info):
         # Construct the TPLinkDeviceInfo here for convenience
         tplink_device_info = TPLinkDeviceInfo(device_info)
         # In case the app_server_url is different, we construct a client each time
@@ -92,7 +86,7 @@ class TPLinkDeviceManager:
             return TPLinkDevice(client, tplink_device_info.device_id, tplink_device_info)
 
     def get_devices(self):
-        return asyncio.run(self._fetch_devices())
+        return self._fetch_devices()
 
     def find_device(self, device_name):
         devices = self.get_devices()

--- a/tplinkcloud/device_manager.py
+++ b/tplinkcloud/device_manager.py
@@ -11,6 +11,7 @@ from .hs105 import HS105
 from .hs110 import HS110
 from .hs300 import HS300
 from .kp115 import KP115
+from .kp303 import KP303
 from .device import TPLinkDevice
 
 
@@ -85,6 +86,8 @@ class TPLinkDeviceManager:
             return HS300(client, tplink_device_info.device_id, tplink_device_info)
         elif tplink_device_info.device_model.startswith('KP115'):
             return KP115(client, tplink_device_info.device_id, tplink_device_info)
+        elif tplink_device_info.device_model.startswith('KP303'):
+            return KP303(client, tplink_device_info.device_id, tplink_device_info)
         else:
             return TPLinkDevice(client, tplink_device_info.device_id, tplink_device_info)
 

--- a/tplinkcloud/device_type.py
+++ b/tplinkcloud/device_type.py
@@ -7,6 +7,8 @@ class TPLinkDeviceType(Enum):
     HS105 = 105
     HS110 = 110
     HS300 = 300
-    HS300CHILD = 301
+    HS300CHILD = 3000
     KP115 = 115
+    KP303 = 303
+    KP303CHILD = 3030
     UNKNOWN = 9999

--- a/tplinkcloud/hs300.py
+++ b/tplinkcloud/hs300.py
@@ -34,7 +34,7 @@ class HS300(TPLinkEMeterDevice):
         super().__init__(client, device_id, device_info)
         self.model_type = TPLinkDeviceType.HS300
 
-    async def get_children(self):
+    def get_children(self):
         sys_info = self.get_sys_info()
         children = []
         if sys_info:

--- a/tplinkcloud/kp303.py
+++ b/tplinkcloud/kp303.py
@@ -34,7 +34,7 @@ class KP303(TPLinkEMeterDevice):
         super().__init__(client, device_id, device_info)
         self.model_type = TPLinkDeviceType.KP303
 
-    async def get_children(self):
+    def get_children(self):
         sys_info = self.get_sys_info()
         children = []
         if sys_info:

--- a/tplinkcloud/kp303.py
+++ b/tplinkcloud/kp303.py
@@ -1,0 +1,55 @@
+from .device_type import TPLinkDeviceType
+from .emeter_device import TPLinkEMeterDevice
+from .kp303_child import KP303Child, KP303ChildSysInfo
+
+
+class KP303SysInfo:
+
+    def __init__(self, sys_info):
+        self.sw_ver = sys_info.get('sw_ver')
+        self.hw_ver = sys_info.get('hw_ver')
+        self.model = sys_info.get('model')
+        self.device_id = sys_info.get('deviceId')
+        self.oem_id = sys_info.get('oemId')
+        self.hw_id = sys_info.get('hwId')
+        self.rssi = sys_info.get('rssi')
+        self.longitude_i = sys_info.get('longitude_i')
+        self.latitude_i = sys_info.get('latitude_i')
+        self.alias = sys_info.get('alias')
+        self.status = sys_info.get('status')
+        self.mic_type = sys_info.get('mic_type')
+        self.feature = sys_info.get('feature')
+        self.mac = sys_info.get('mac')
+        self.updating = sys_info.get('updating')
+        self.led_off = sys_info.get('led_off')
+        self.children = [KP303ChildSysInfo(child_info)
+                         for child_info in sys_info.get('children')]
+        self.child_num = sys_info.get('child_num')
+        self.err_code = sys_info.get('err_code')
+
+
+class KP303(TPLinkEMeterDevice):
+
+    def __init__(self, client, device_id, device_info):
+        super().__init__(client, device_id, device_info)
+        self.model_type = TPLinkDeviceType.KP303
+
+    async def get_children(self):
+        sys_info = self.get_sys_info()
+        children = []
+        if sys_info:
+            for child_info in sys_info.children:
+                device_child = KP303Child(
+                    self._client, sys_info.device_id, child_info.id, child_info)
+                children.append(device_child)
+        return children
+
+    # An override of an identified TPLinkDevice
+    def has_children(self):
+        return True
+
+    def get_sys_info(self):
+        sys_info = self._get_sys_info()
+        if sys_info:
+            return KP303SysInfo(sys_info)
+        return None

--- a/tplinkcloud/kp303_child.py
+++ b/tplinkcloud/kp303_child.py
@@ -1,0 +1,35 @@
+from .device_type import TPLinkDeviceType
+from .emeter_device import TPLinkEMeterDevice
+
+
+class KP303ChildAction:
+    def __init__(self, child_action):
+        self.type = child_action.get('type')
+        self.schd_sec = child_action.get('schd_sec')
+        self.action = child_action.get('action')
+
+
+class KP303ChildSysInfo:
+
+    def __init__(self, child_info):
+        self.id = child_info.get('id')
+        self.state = child_info.get('state')
+        self.alias = child_info.get('alias')
+        self.on_time = child_info.get('on_time')
+        self.next_action = KP303ChildAction(child_info.get('next_action'))
+
+
+class KP303Child(TPLinkEMeterDevice):
+
+    def __init__(self, client, parent_device_id, child_device_id, device_info):
+        super().__init__(
+            client,
+            parent_device_id,
+            device_info,
+            child_id=child_device_id
+        )
+        self.model_type = TPLinkDeviceType.KP303CHILD
+
+    def get_sys_info(self):
+        sys_info = self._get_sys_info()
+        return KP303ChildSysInfo(sys_info)


### PR DESCRIPTION
This also includes a reversion of the async code, most importantly around `get_devices` which as a top-level call should not have required that consumers use `asyncio.run` to execute. Async code for this project is intended to function behind the scenes and the rudimentary implementation was not actually making anything any faster. Implementing async requests to the TP-Link API will be revisited at a later time.