### PR TITLE
v2.1.2 Inform User of sys_info failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.1.1'
+__version__ = '2.1.2'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tplinkcloud/hs100.py
+++ b/tplinkcloud/hs100.py
@@ -43,4 +43,9 @@ class HS100(TPLinkEMeterDevice):
 
     def get_sys_info(self):
         sys_info = self._get_sys_info()
+        
+        if not sys_info:
+            print("Something went wrong with your request; please try again")
+            return None
+        
         return HS100SysInfo(sys_info)

--- a/tplinkcloud/hs103.py
+++ b/tplinkcloud/hs103.py
@@ -44,4 +44,9 @@ class HS103(TPLinkDevice):
 
     def get_sys_info(self):
         sys_info = self._get_sys_info()
+        
+        if not sys_info:
+            print("Something went wrong with your request; please try again")
+            return None
+        
         return HS103SysInfo(sys_info)

--- a/tplinkcloud/hs105.py
+++ b/tplinkcloud/hs105.py
@@ -44,4 +44,9 @@ class HS105(TPLinkDevice):
 
     def get_sys_info(self):
         sys_info = self._get_sys_info()
+
+        if not sys_info:
+            print("Something went wrong with your request; please try again")
+            return None
+        
         return HS105SysInfo(sys_info)

--- a/tplinkcloud/hs110.py
+++ b/tplinkcloud/hs110.py
@@ -16,4 +16,9 @@ class HS110(HS100):
 
     def get_sys_info(self):
         sys_info = self._get_sys_info()
+        
+        if not sys_info:
+            print("Something went wrong with your request; please try again")
+            return None
+        
         return HS110SysInfo(sys_info)

--- a/tplinkcloud/hs300.py
+++ b/tplinkcloud/hs300.py
@@ -50,6 +50,9 @@ class HS300(TPLinkEMeterDevice):
 
     def get_sys_info(self):
         sys_info = self._get_sys_info()
-        if sys_info:
-            return HS300SysInfo(sys_info)
-        return None
+        
+        if not sys_info:
+            print("Something went wrong with your request; please try again")
+            return None
+        
+        return HS300SysInfo(sys_info)

--- a/tplinkcloud/hs300_child.py
+++ b/tplinkcloud/hs300_child.py
@@ -32,4 +32,9 @@ class HS300Child(TPLinkEMeterDevice):
 
     def get_sys_info(self):
         sys_info = self._get_sys_info()
+        
+        if not sys_info:
+            print("Something went wrong with your request; please try again")
+            return None
+        
         return HS300ChildSysInfo(sys_info)

--- a/tplinkcloud/kp115.py
+++ b/tplinkcloud/kp115.py
@@ -16,4 +16,9 @@ class KP115(HS110):
 
     def get_sys_info(self):
         sys_info = self._get_sys_info()
+        
+        if not sys_info:
+            print("Something went wrong with your request; please try again")
+            return None
+        
         return KP115SysInfo(sys_info)

--- a/tplinkcloud/kp303.py
+++ b/tplinkcloud/kp303.py
@@ -50,6 +50,9 @@ class KP303(TPLinkEMeterDevice):
 
     def get_sys_info(self):
         sys_info = self._get_sys_info()
-        if sys_info:
-            return KP303SysInfo(sys_info)
-        return None
+        
+        if not sys_info:
+            print("Something went wrong with your request; please try again")
+            return None
+        
+        return KP303SysInfo(sys_info)

--- a/tplinkcloud/kp303_child.py
+++ b/tplinkcloud/kp303_child.py
@@ -32,4 +32,9 @@ class KP303Child(TPLinkEMeterDevice):
 
     def get_sys_info(self):
         sys_info = self._get_sys_info()
+        
+        if not sys_info:
+            print("Something went wrong with your request; please try again")
+            return None
+        
         return KP303ChildSysInfo(sys_info)


### PR DESCRIPTION
Rather than ending up with a stack trace when sys_info was not able to be fetched, instead print out a message and return `None`.