### PR TITLE
Check for empty username and password before attempting login

### DIFF
--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -190,3 +190,29 @@ class TestFindDevices(object):
 
         assert devices is not None
         assert len(devices) == 2
+
+class TestAuth(object):
+
+    def test_auth_empty_string(self, client):
+        with pytest.raises(Exception):
+            TPLinkDeviceManager(
+                username="",
+                password="",
+                prefetch=False,
+                cache_devices=False,
+                tplink_cloud_api_host=os.environ.get('TPLINK_KASA_API_URL'),
+                verbose=False,
+                term_id=os.environ.get('TPLINK_KASA_TERM_ID')
+            )
+
+    def test_auth_none(self, client):
+        with pytest.raises(Exception):
+            TPLinkDeviceManager(
+                username=None,
+                password=None,
+                prefetch=False,
+                cache_devices=False,
+                tplink_cloud_api_host=os.environ.get('TPLINK_KASA_API_URL'),
+                verbose=False,
+                term_id=os.environ.get('TPLINK_KASA_TERM_ID')
+            )

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -193,11 +193,11 @@ class TestFindDevices(object):
 
 class TestAuth(object):
 
-    def test_auth_empty_string(self, client):
-        with pytest.raises(Exception):
+    def test_auth_no_username(self, client):
+        with pytest.raises(ValueError):
             TPLinkDeviceManager(
-                username="",
-                password="",
+                username=None,
+                password=os.environ.get('TPLINK_KASA_PASSWORD'),
                 prefetch=False,
                 cache_devices=False,
                 tplink_cloud_api_host=os.environ.get('TPLINK_KASA_API_URL'),
@@ -205,10 +205,10 @@ class TestAuth(object):
                 term_id=os.environ.get('TPLINK_KASA_TERM_ID')
             )
 
-    def test_auth_none(self, client):
-        with pytest.raises(Exception):
+    def test_auth_no_password(self, client):
+        with pytest.raises(ValueError):
             TPLinkDeviceManager(
-                username=None,
+                username=os.environ.get('TPLINK_KASA_USERNAME'),
                 password=None,
                 prefetch=False,
                 cache_devices=False,

--- a/tplinkcloud/client.py
+++ b/tplinkcloud/client.py
@@ -58,9 +58,9 @@ class TPLinkApi:
 
     # Returns a token if properly authenticated
     def login(self, username, password):
-        if username is None:
+        if username is None or username == "":
             raise Exception("Cannot login, username is not set")
-        if password is None:
+        if password is None or password == "":
             raise Exception("Cannot login, password not set")
         body = {
             'method': 'login',

--- a/tplinkcloud/client.py
+++ b/tplinkcloud/client.py
@@ -58,10 +58,10 @@ class TPLinkApi:
 
     # Returns a token if properly authenticated
     def login(self, username, password):
-        if username is None or username == "":
-            raise Exception("Cannot login, username is not set")
-        if password is None or password == "":
-            raise Exception("Cannot login, password not set")
+        if not username:
+            raise ValueError("Cannot login, username is not set")
+        if not password:
+            raise ValueError("Cannot login, password not set")
         body = {
             'method': 'login',
             'url': self.host,

--- a/tplinkcloud/client.py
+++ b/tplinkcloud/client.py
@@ -58,6 +58,10 @@ class TPLinkApi:
 
     # Returns a token if properly authenticated
     def login(self, username, password):
+        if username is None:
+            raise Exception("Cannot login, username is not set")
+        if password is None:
+            raise Exception("Cannot login, password not set")
         body = {
             'method': 'login',
             'url': self.host,


### PR DESCRIPTION
While attempting to list devices the request always returned empty. I tracked it down to an empty username and password environment variables that I thought were set. There were no clear errors that it was an authentication issue. This PR adds validation for empty username and password as well as tests.

Python isn't my strongest language so there might be a better way to do this.