### PR TITLE
v2.2.0 Add get_net_info capability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.1.3'
+__version__ = '2.2.0'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tests/test_hs103_us.py
+++ b/tests/test_hs103_us.py
@@ -23,7 +23,6 @@ class TestHS103USDevice(object):
     def test_get_sys_info_gets_info(self, client):
         device_name = 'Bedroom Desk Light'
         device = client.find_device(device_name)
-        print(device.get_alias())
         sys_info = device.get_sys_info()
 
         assert sys_info is not None

--- a/tests/test_tp_link_device.py
+++ b/tests/test_tp_link_device.py
@@ -1,0 +1,32 @@
+import os
+import pytest
+
+from tplinkcloud import TPLinkDeviceManager
+
+
+@pytest.fixture(scope='module')
+def client():
+    return TPLinkDeviceManager(
+        username=os.environ.get('TPLINK_KASA_USERNAME'),
+        password=os.environ.get('TPLINK_KASA_PASSWORD'),
+        prefetch=False,
+        cache_devices=False,
+        tplink_cloud_api_host=os.environ.get('TPLINK_KASA_API_URL'),
+        verbose=True,
+        term_id=os.environ.get('TPLINK_KASA_TERM_ID')
+    )
+
+
+@pytest.mark.usefixtures('client')
+class TestTPLinkDevice(object):
+
+    def test_get_net_info_gets_net_info(self, client):
+        device_name = 'Left Lamp'
+        device = client.find_device(device_name)
+        net_info = device.get_net_info()
+
+        assert net_info is not None
+        assert net_info.ssid == "My WiFi Network"
+        assert net_info.key_type == 3
+        assert net_info.rssi == -39
+        assert net_info.err_code == 0

--- a/tests/wiremock/__files/get_device_net_info_response.json
+++ b/tests/wiremock/__files/get_device_net_info_response.json
@@ -1,0 +1,6 @@
+{
+    "error_code": 0,
+    "result": {
+        "responseData": "{\"netif\":{\"get_stainfo\":{\"ssid\":\"My WiFi Network\",\"key_type\":3,\"rssi\":-39,\"err_code\":0}}}"
+    }
+}

--- a/tests/wiremock/mappings/get_device_net_info_request.json
+++ b/tests/wiremock/mappings/get_device_net_info_request.json
@@ -1,0 +1,25 @@
+{
+    "request": {
+        "method": "POST",
+        "url": "/?appName=Kasa_Android&termID=2a8ced52-f200-4b79-a1fe-2f6b58193c4c&appVer=1.4.4.607&ospf=Android%2B6.0.1&netType=wifi&locale=es_ES&token=abcdef-AB1234cdeTKJH123kja0",
+        "bodyPatterns": [
+            {
+                "equalToJson" : { 
+                    "method": "passthrough",
+                    "params": {
+                        "deviceId": "9F231AD114D92FE98DEB7843ADC91D0EEEF2D0B8",
+                        "requestData": "{\"netif\": {\"get_stainfo\": null}}"
+                    }
+                }
+            }
+        ],
+        "headers": {
+            "User-Agent": { "equalTo": "Dalvik/2.1.0 (Linux; U; Android 6.0.1; A0001 Build/M4B30X)" },
+            "Content-Type": { "equalTo": "application/json" }
+        }
+    },
+    "response": {
+        "status": 200,
+        "bodyFileName": "get_device_net_info_response.json"
+    }
+}

--- a/tplinkcloud/device.py
+++ b/tplinkcloud/device.py
@@ -1,4 +1,5 @@
 from .device_type import TPLinkDeviceType
+from .device_net_info import DeviceNetInfo
 
 
 class TPLinkDevice:
@@ -95,3 +96,10 @@ class TPLinkDevice:
 
     def edit_schedule_rule(self, rule):
         return self._pass_through_request('schedule', 'edit_rule', rule)
+
+    # Get SSID of network to which the device is connected
+    def get_net_info(self):
+        net_info = self._pass_through_request('netif', 'get_stainfo', None)
+        if net_info:
+            return DeviceNetInfo(net_info)
+        return None

--- a/tplinkcloud/device_net_info.py
+++ b/tplinkcloud/device_net_info.py
@@ -1,0 +1,8 @@
+class DeviceNetInfo:
+
+    def __init__(self, net_info):
+        # This should be the name of your network
+        self.ssid = net_info.get('ssid')
+        self.key_type = net_info.get('key_type')
+        self.rssi = net_info.get('rssi')
+        self.err_code = net_info.get('err_code')


### PR DESCRIPTION
This is for all devices including emeter devices.

This is being written in response to this feature request https://github.com/piekstra/tplink-cloud-api/issues/21

There are more features requested in that issue that I plan to add after this one.