### PR TITLE
v2.3.0 Add get_device_time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.2.0'
+__version__ = '2.3.0'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tests/test_tp_link_device.py
+++ b/tests/test_tp_link_device.py
@@ -30,3 +30,17 @@ class TestTPLinkDevice(object):
         assert net_info.key_type == 3
         assert net_info.rssi == -39
         assert net_info.err_code == 0
+
+    def test_get_time_gets_time(self, client):
+        device_name = 'Left Lamp'
+        device = client.find_device(device_name)
+        time = device.get_time()
+
+        assert time is not None
+        assert time.year == 2021
+        assert time.month == 3
+        assert time.mday == 22
+        assert time.hour == 12
+        assert time.min == 55
+        assert time.sec == 41
+        assert time.err_code == 0

--- a/tests/wiremock/__files/get_device_time_response.json
+++ b/tests/wiremock/__files/get_device_time_response.json
@@ -1,0 +1,6 @@
+{
+    "error_code": 0,
+    "result": {
+        "responseData": "{\"time\":{\"get_time\":{\"year\":2021,\"month\":3,\"mday\":22,\"hour\":12,\"min\":55,\"sec\":41,\"err_code\":0}}}"
+    }
+}

--- a/tests/wiremock/mappings/get_device_time_request.json
+++ b/tests/wiremock/mappings/get_device_time_request.json
@@ -1,0 +1,25 @@
+{
+    "request": {
+        "method": "POST",
+        "url": "/?appName=Kasa_Android&termID=2a8ced52-f200-4b79-a1fe-2f6b58193c4c&appVer=1.4.4.607&ospf=Android%2B6.0.1&netType=wifi&locale=es_ES&token=abcdef-AB1234cdeTKJH123kja0",
+        "bodyPatterns": [
+            {
+                "equalToJson" : { 
+                    "method": "passthrough",
+                    "params": {
+                        "deviceId": "9F231AD114D92FE98DEB7843ADC91D0EEEF2D0B8",
+                        "requestData": "{\"time\": {\"get_time\": {}}}"
+                    }
+                }
+            }
+        ],
+        "headers": {
+            "User-Agent": { "equalTo": "Dalvik/2.1.0 (Linux; U; Android 6.0.1; A0001 Build/M4B30X)" },
+            "Content-Type": { "equalTo": "application/json" }
+        }
+    },
+    "response": {
+        "status": 200,
+        "bodyFileName": "get_device_time_response.json"
+    }
+}

--- a/tplinkcloud/device.py
+++ b/tplinkcloud/device.py
@@ -1,5 +1,6 @@
 from .device_type import TPLinkDeviceType
 from .device_net_info import DeviceNetInfo
+from .device_time import DeviceTime
 
 
 class TPLinkDevice:
@@ -102,4 +103,11 @@ class TPLinkDevice:
         net_info = self._pass_through_request('netif', 'get_stainfo', None)
         if net_info:
             return DeviceNetInfo(net_info)
+        return None
+
+    # Get device current time
+    def get_time(self):
+        time = self._pass_through_request('time', 'get_time', {})
+        if time:
+            return DeviceTime(time)
         return None

--- a/tplinkcloud/device_time.py
+++ b/tplinkcloud/device_time.py
@@ -1,0 +1,10 @@
+class DeviceTime:
+    
+    def __init__(self, time):
+        self.year = time.get('year')
+        self.month = time.get('month')
+        self.mday = time.get('mday')
+        self.hour = time.get('hour')
+        self.min = time.get('min')
+        self.sec = time.get('sec')
+        self.err_code = time.get('err_code')


### PR DESCRIPTION
Functionality to get the time for a device. This PR is being created in response to the feature requests listed in this issue: https://github.com/piekstra/tplink-cloud-api/issues/21