### PR TITLE
v2.4.0 Add get_children_async

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.22.0
+aiohttp==3.7.4

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.3.0'
+__version__ = '2.4.0'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()
@@ -17,7 +17,8 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        'requests==2.22.0'
+        'requests==2.22.0',
+        'aiohttp==3.7.4'
     ],
     url='https://github.com/piekstra/tplink-cloud-api',
     python_requires='>=3.7',

--- a/tplinkcloud/hs300.py
+++ b/tplinkcloud/hs300.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from .device_type import TPLinkDeviceType
 from .emeter_device import TPLinkEMeterDevice
 from .hs300_child import HS300Child, HS300ChildSysInfo
@@ -34,8 +36,8 @@ class HS300(TPLinkEMeterDevice):
         super().__init__(client, device_id, device_info)
         self.model_type = TPLinkDeviceType.HS300
 
-    def get_children(self):
-        sys_info = self.get_sys_info()
+    async def get_children_async(self):
+        sys_info = await self.get_sys_info_async()
         children = []
         if sys_info:
             for child_info in sys_info.children:
@@ -48,11 +50,14 @@ class HS300(TPLinkEMeterDevice):
     def has_children(self):
         return True
 
-    def get_sys_info(self):
-        sys_info = self._get_sys_info()
+    async def get_sys_info_async(self):
+        sys_info = await self._get_sys_info_async()
         
         if not sys_info:
             print("Something went wrong with your request; please try again")
             return None
         
         return HS300SysInfo(sys_info)
+    
+    def get_sys_info(self):
+        return asyncio.run(self.get_sys_info_async())

--- a/tplinkcloud/kp303.py
+++ b/tplinkcloud/kp303.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from .device_type import TPLinkDeviceType
 from .emeter_device import TPLinkEMeterDevice
 from .kp303_child import KP303Child, KP303ChildSysInfo
@@ -34,8 +36,8 @@ class KP303(TPLinkEMeterDevice):
         super().__init__(client, device_id, device_info)
         self.model_type = TPLinkDeviceType.KP303
 
-    def get_children(self):
-        sys_info = self.get_sys_info()
+    async def get_children_async(self):
+        sys_info = await self.get_sys_info_async()
         children = []
         if sys_info:
             for child_info in sys_info.children:
@@ -48,11 +50,14 @@ class KP303(TPLinkEMeterDevice):
     def has_children(self):
         return True
 
-    def get_sys_info(self):
-        sys_info = self._get_sys_info()
+    async def get_sys_info_async(self):
+        sys_info = await self._get_sys_info_async()
         
         if not sys_info:
             print("Something went wrong with your request; please try again")
             return None
         
         return KP303SysInfo(sys_info)
+        
+    def get_sys_info(self):
+        return asyncio.run(self.get_sys_info_async())


### PR DESCRIPTION
### New Dependencies
* aiohttp==3.7.4

In order to fetch children for devices that support them, specifically HS300 and KP303, the sys_info for the "parent" device has to be requested. This extra call can add up when there are multiple parent devices associated with your account and the total time spent to get devices would grow linearly with the number of devices you have with children. This can be especially painful when using the "prefetch" feature for constructing a device manager as you won't be able to use the manager until all of those requests have been completed.

With this change, children can be gathered async and so rather than wait on each device's `get_children` method sequentially, this will instead gather up all of the async "children gathering" tasks, then wait on the lot of them to complete.

This change was made with the intent of being backwards-compatible so as to avoid breaking any uses of "public" methods (those without a `_` preceding their name).

Note that the original `get_children` method has been moved to the `TPLinkDevice` class as it simply calls the new async version.