### PR TITLE
v2.4.1 KP303 do not support EMeter functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.4.0'
+__version__ = '2.4.1'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tplinkcloud/kp303.py
+++ b/tplinkcloud/kp303.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from .device_type import TPLinkDeviceType
-from .emeter_device import TPLinkEMeterDevice
+from .device import TPLinkDevice
 from .kp303_child import KP303Child, KP303ChildSysInfo
 
 
@@ -30,7 +30,7 @@ class KP303SysInfo:
         self.err_code = sys_info.get('err_code')
 
 
-class KP303(TPLinkEMeterDevice):
+class KP303(TPLinkDevice):
 
     def __init__(self, client, device_id, device_info):
         super().__init__(client, device_id, device_info)

--- a/tplinkcloud/kp303_child.py
+++ b/tplinkcloud/kp303_child.py
@@ -1,5 +1,5 @@
 from .device_type import TPLinkDeviceType
-from .emeter_device import TPLinkEMeterDevice
+from .device import TPLinkDevice
 
 
 class KP303ChildAction:
@@ -19,7 +19,7 @@ class KP303ChildSysInfo:
         self.next_action = KP303ChildAction(child_info.get('next_action'))
 
 
-class KP303Child(TPLinkEMeterDevice):
+class KP303Child(TPLinkDevice):
 
     def __init__(self, client, parent_device_id, child_device_id, device_info):
         super().__init__(


### PR DESCRIPTION
As I do not have a device locally to test out KP303 functionality, I had assumed that the KP303 has the same functionalities as the larger HS300. As it turns out, KP303 devices to not support the EMeter functionality.