### PR TITLE
v2.4.2 Add auth param checking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.4.1'
+__version__ = '2.4.2'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -191,6 +191,7 @@ class TestFindDevices(object):
         assert devices is not None
         assert len(devices) == 2
 
+@pytest.mark.usefixtures('client')
 class TestAuth(object):
 
     def test_auth_no_username(self, client):


### PR DESCRIPTION
When constructing a device manager, it's necessary to provide a username and password for authenticating with the TP-Link Kasa API. As such, there needs to be checks that these values are specified to avoid any silent failures.