### PR TITLE
v2.6.0 Add has_emeter convenience function

### DIFF
--- a/tests/test_hs103_us.py
+++ b/tests/test_hs103_us.py
@@ -50,3 +50,11 @@ class TestHS103USDevice(object):
         assert sys_info.next_action is not None
         assert sys_info.next_action.action == -1
         assert sys_info.err_code == 0
+
+    def test_has_emeter_returns_false(self, client):
+        device_name = 'Bedroom Desk Light'
+        device = client.find_device(device_name)
+        has_emeter = device.has_emeter()
+
+        assert has_emeter is not None
+        assert has_emeter == False

--- a/tests/test_hs300_us.py
+++ b/tests/test_hs300_us.py
@@ -96,3 +96,19 @@ class TestHS300USDevice(object):
         assert sys_info.children[5].next_action.type == -1
         assert sys_info.children[5].next_action.schd_sec is None
         assert sys_info.children[5].next_action.action is None
+
+    def test_has_emeter_returns_false_for_parent(self, client):
+        device_name = 'TP-LINK_Power Strip_9704'
+        parent_device = client.find_device(device_name)
+        has_emeter = parent_device.has_emeter()
+
+        assert has_emeter is not None
+        assert has_emeter == False
+
+    def test_has_emeter_returns_true_for_child(self, client):
+        device_name = 'Plug 6'
+        child_device = client.find_device(device_name)
+        has_emeter = child_device.has_emeter()
+
+        assert has_emeter is not None
+        assert has_emeter == True

--- a/tplinkcloud/device.py
+++ b/tplinkcloud/device.py
@@ -27,6 +27,10 @@ class TPLinkDevice:
     def get_children(self):
         return asyncio.run(self.get_children_async())
 
+    # This is expected to be overriden for emeter devices
+    def has_emeter(self):
+        return False
+
     def get_alias(self):
         return self.device_info.alias
 

--- a/tplinkcloud/emeter_device.py
+++ b/tplinkcloud/emeter_device.py
@@ -31,6 +31,10 @@ class TPLinkEMeterDevice(TPLinkDevice):
 
     def __init__(self, client, device_id, device_info, child_id=None):
         super().__init__(client, device_id, device_info, child_id)
+    
+    # This is an override for regular devices
+    def has_emeter(self):
+        return True
 
     def get_power_usage_realtime(self):
         realtime_data = self._pass_through_request(

--- a/tplinkcloud/hs300.py
+++ b/tplinkcloud/hs300.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from .device_type import TPLinkDeviceType
-from .emeter_device import TPLinkEMeterDevice
+from .device import TPLinkDevice
 from .hs300_child import HS300Child, HS300ChildSysInfo
 
 
@@ -30,7 +30,7 @@ class HS300SysInfo:
         self.err_code = sys_info.get('err_code')
 
 
-class HS300(TPLinkEMeterDevice):
+class HS300(TPLinkDevice):
 
     def __init__(self, client, device_id, device_info):
         super().__init__(client, device_id, device_info)


### PR DESCRIPTION
This function is intended to be an easy way to check if a device has emeter capabilities and therefore can get electricity data.

Note that this also includes a bugfix - HS300 devices themselves as an entity here do not have emeter functionality. It is their children (HS300Child - the individual plugs on the power strip) that have that functionality.