### PR TITLE
v2.6.1 Fix uncaught exception on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.6.0'
+__version__ = '2.6.1'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tplinkcloud/__init__.py
+++ b/tplinkcloud/__init__.py
@@ -1,3 +1,25 @@
 from .device_manager import TPLinkDeviceManager
 
 __all__ = ['TPLinkDeviceManager', ]
+
+# Windows OS-specific HACK to silence exception thrown on event loop being closed
+# as part of the asyncio library's proactor
+# Hack sourced from an issue on the aiohttp library:
+#   https://github.com/aio-libs/aiohttp/issues/4324#issuecomment-733884349
+# This assumes you have the asyncio library installed
+import platform
+if platform.system() == 'Windows':
+    from functools import wraps
+    from asyncio.proactor_events import _ProactorBasePipeTransport
+
+    def silence_event_loop_closed(func):
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            try:
+                return func(self, *args, **kwargs)
+            except RuntimeError as e:
+                if str(e) != 'Event loop is closed':
+                    raise
+        return wrapper
+
+    _ProactorBasePipeTransport.__del__ = silence_event_loop_closed(_ProactorBasePipeTransport.__del__)


### PR DESCRIPTION
This change is a Windows OS-specific HACK to silence an exception thrown on the asyncio event loop being closed as part of the asyncio library's proactor.

Note that the exception is technically harmless to the library's functionality, but it is a poor user experience to see exceptions with normal usage.

Hack sourced from an issue on the aiohttp library: https://github.com/aio-libs/aiohttp/issues/4324#issuecomment-733884349

This is being created in response to this issue: https://github.com/piekstra/tplink-cloud-api/issues/31