### PR TITLE
v2.8.0 Refine get_schedule_rules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.7.0'
+__version__ = '2.8.0'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tests/test_tp_link_device.py
+++ b/tests/test_tp_link_device.py
@@ -53,3 +53,180 @@ class TestTPLinkDevice(object):
         assert timezone is not None
         assert timezone.index == 6
         assert timezone.err_code == 0
+
+
+@pytest.mark.usefixtures('client')
+class TestTPLinkDeviceSchedule(object):
+
+    def test_get_schedule_rules_gets_schedule_rules(self, client):
+        device_name = 'Left Lamp'
+        device = client.find_device(device_name)
+        schedule = device.get_schedule_rules()
+
+        assert schedule is not None
+        # Unsure what this field is for
+        assert schedule.version is None
+        assert schedule.enable == 1
+        assert schedule.err_code == 0
+        assert schedule.rules is not None
+        assert len(schedule.rules) == 4
+
+        # Time-based schedule rule
+        assert schedule.rules[0].id == '7B0F854D3C0384E48EF88E0187BD8F34'
+        assert schedule.rules[0].name == 'Schedule Rule'
+
+        assert schedule.rules[0].enable == 1
+        assert schedule.rules[0].enabled
+
+        assert schedule.rules[0].wday == [1,0,1,1,0,1,1]
+        assert schedule.rules[0].sunday_enabled
+        assert not schedule.rules[0].monday_enabled
+        assert schedule.rules[0].tuesday_enabled
+        assert schedule.rules[0].wednesday_enabled
+        assert not schedule.rules[0].thursday_enabled
+        assert schedule.rules[0].friday_enabled
+        assert schedule.rules[0].saturday_enabled
+
+        assert schedule.rules[0].stime_opt == 0
+        assert schedule.rules[0].start_type.name == 'Time'
+
+        assert schedule.rules[0].soffset is None
+        assert schedule.rules[0].smin == 705
+        assert schedule.rules[0].hour == 11
+        assert schedule.rules[0].minute == 45
+
+        assert schedule.rules[0].sact == 1
+        assert schedule.rules[0].turn_on
+        assert not schedule.rules[0].turn_off
+
+        assert schedule.rules[0].etime_opt == -1
+        assert schedule.rules[0].eoffset is None
+        assert schedule.rules[0].emin == 0
+        assert schedule.rules[0].eact == -1
+
+        assert schedule.rules[0].repeat == 1
+        assert schedule.rules[0].repeated
+
+        assert schedule.rules[0].year == 0
+        assert schedule.rules[0].month == 0
+        assert schedule.rules[0].day == 0
+
+        # Sunrise schedule rule
+        assert schedule.rules[1].id == 'E6F1B23B134009FDDEA89E59F46E8708'
+        assert schedule.rules[1].name == 'Schedule Rule'
+
+        assert schedule.rules[1].enable == 1
+        assert schedule.rules[1].enabled
+
+        assert schedule.rules[1].wday == [1,1,1,1,1,1,1]
+        assert schedule.rules[1].sunday_enabled
+        assert schedule.rules[1].monday_enabled
+        assert schedule.rules[1].tuesday_enabled
+        assert schedule.rules[1].wednesday_enabled
+        assert schedule.rules[1].thursday_enabled
+        assert schedule.rules[1].friday_enabled
+        assert schedule.rules[1].saturday_enabled
+
+        assert schedule.rules[1].stime_opt == 1
+        assert schedule.rules[1].start_type.name == 'Sunrise'
+
+        assert schedule.rules[1].soffset is None
+        assert schedule.rules[1].smin == 389
+        assert schedule.rules[1].hour == 6
+        assert schedule.rules[1].minute == 29
+
+        assert schedule.rules[1].sact == 1
+        assert schedule.rules[1].turn_on
+        assert not schedule.rules[1].turn_off
+
+        assert schedule.rules[1].etime_opt == -1
+        assert schedule.rules[1].eoffset is None
+        assert schedule.rules[1].emin == 0
+        assert schedule.rules[1].eact == -1
+
+        assert schedule.rules[1].repeat == 1
+        assert schedule.rules[1].repeated
+
+        assert schedule.rules[1].year == 0
+        assert schedule.rules[1].month == 0
+        assert schedule.rules[1].day == 0
+
+        # Sunset schedule rule
+        assert schedule.rules[2].id == '558AD8513338E5A4154CFC595BA72B83'
+        assert schedule.rules[2].name == 'Schedule Rule'
+
+        assert schedule.rules[2].enable == 1
+        assert schedule.rules[2].enabled
+
+        assert schedule.rules[2].wday == [0,1,1,1,1,1,0]
+        assert not schedule.rules[2].sunday_enabled
+        assert schedule.rules[2].monday_enabled
+        assert schedule.rules[2].tuesday_enabled
+        assert schedule.rules[2].wednesday_enabled
+        assert schedule.rules[2].thursday_enabled
+        assert schedule.rules[2].friday_enabled
+        assert not schedule.rules[2].saturday_enabled
+
+        assert schedule.rules[2].stime_opt == 2
+        assert schedule.rules[2].start_type.name == 'Sunset'
+
+        assert schedule.rules[2].soffset is None
+        assert schedule.rules[2].smin == 1195
+        assert schedule.rules[2].hour == 19
+        assert schedule.rules[2].minute == 55
+
+        assert schedule.rules[2].sact == 0
+        assert not schedule.rules[2].turn_on
+        assert schedule.rules[2].turn_off
+
+        assert schedule.rules[2].etime_opt == -1
+        assert schedule.rules[2].eoffset is None
+        assert schedule.rules[2].emin == 0
+        assert schedule.rules[2].eact == -1
+
+        assert schedule.rules[2].repeat == 1
+        assert schedule.rules[2].repeated
+
+        assert schedule.rules[2].year == 0
+        assert schedule.rules[2].month == 0
+        assert schedule.rules[2].day == 0
+
+        # One-off Time-based schedule rule
+        assert schedule.rules[3].id == 'FF24375EB7DD5F3D9AEFE22EAA11E436'
+        assert schedule.rules[3].name == 'Schedule Rule'
+
+        assert schedule.rules[3].enable == 0
+        assert not schedule.rules[3].enabled
+
+        assert schedule.rules[3].wday == [1,0,0,0,0,0,0]
+        assert schedule.rules[3].sunday_enabled
+        assert not schedule.rules[3].monday_enabled
+        assert not schedule.rules[3].tuesday_enabled
+        assert not schedule.rules[3].wednesday_enabled
+        assert not schedule.rules[3].thursday_enabled
+        assert not schedule.rules[3].friday_enabled
+        assert not schedule.rules[3].saturday_enabled
+
+        assert schedule.rules[3].stime_opt == 0
+        assert schedule.rules[3].start_type.name == 'Time'
+
+        assert schedule.rules[3].soffset is None
+        assert schedule.rules[3].smin == 719
+        assert schedule.rules[3].hour == 11
+        assert schedule.rules[3].minute == 59
+
+        assert schedule.rules[3].sact == 0
+        assert not schedule.rules[3].turn_on
+        assert schedule.rules[3].turn_off
+
+        assert schedule.rules[3].etime_opt == -1
+        assert schedule.rules[3].eoffset is None
+        assert schedule.rules[3].emin == 0
+        assert schedule.rules[3].eact == -1
+
+        assert schedule.rules[3].repeat == 0
+        assert not schedule.rules[3].repeated
+
+        assert schedule.rules[3].year == 2021
+        assert schedule.rules[3].month == 4
+        assert schedule.rules[3].day == 11

--- a/tests/wiremock/__files/get_device_schedule_rules_response.json
+++ b/tests/wiremock/__files/get_device_schedule_rules_response.json
@@ -1,0 +1,6 @@
+{
+    "error_code": 0,
+    "result": {
+        "responseData": "{\"schedule\":{\"get_rules\":{\"enable\":1,\"rule_list\":[{\"enable\":1,\"id\":\"7B0F854D3C0384E48EF88E0187BD8F34\",\"name\":\"Schedule Rule\",\"stime_opt\":0,\"smin\":705,\"sact\":1,\"etime_opt\":-1,\"emin\":0,\"eact\":-1,\"wday\":[1,0,1,1,0,1,1],\"repeat\":1,\"year\":0,\"month\":0,\"day\":0},{\"enable\":1,\"id\":\"E6F1B23B134009FDDEA89E59F46E8708\",\"name\":\"Schedule Rule\",\"stime_opt\":1,\"smin\":389,\"sact\":1,\"etime_opt\":-1,\"emin\":0,\"eact\":-1,\"wday\":[1,1,1,1,1,1,1],\"repeat\":1,\"year\":0,\"month\":0,\"day\":0},{\"enable\":1,\"id\":\"558AD8513338E5A4154CFC595BA72B83\",\"name\":\"Schedule Rule\",\"stime_opt\":2,\"smin\":1195,\"sact\":0,\"etime_opt\":-1,\"emin\":0,\"eact\":-1,\"wday\":[0,1,1,1,1,1,0],\"repeat\":1,\"year\":0,\"month\":0,\"day\":0},{\"enable\":0,\"id\":\"FF24375EB7DD5F3D9AEFE22EAA11E436\",\"name\":\"Schedule Rule\",\"stime_opt\":0,\"smin\":719,\"sact\":0,\"etime_opt\":-1,\"emin\":0,\"eact\":-1,\"wday\":[1,0,0,0,0,0,0],\"repeat\":0,\"year\":2021,\"month\":4,\"day\":11}],\"err_code\":0}}}"
+    }
+}

--- a/tests/wiremock/mappings/get_device_schedule_rules_request.json
+++ b/tests/wiremock/mappings/get_device_schedule_rules_request.json
@@ -1,0 +1,25 @@
+{
+    "request": {
+        "method": "POST",
+        "url": "/?appName=Kasa_Android&termID=2a8ced52-f200-4b79-a1fe-2f6b58193c4c&appVer=1.4.4.607&ospf=Android%2B6.0.1&netType=wifi&locale=es_ES&token=abcdef-AB1234cdeTKJH123kja0",
+        "bodyPatterns": [
+            {
+                "equalToJson" : { 
+                    "method": "passthrough",
+                    "params": {
+                        "deviceId": "9F231AD114D92FE98DEB7843ADC91D0EEEF2D0B8",
+                        "requestData": "{\"schedule\": {\"get_rules\": {}}}"
+                    }
+                }
+            }
+        ],
+        "headers": {
+            "User-Agent": { "equalTo": "Dalvik/2.1.0 (Linux; U; Android 6.0.1; A0001 Build/M4B30X)" },
+            "Content-Type": { "equalTo": "application/json" }
+        }
+    },
+    "response": {
+        "status": 200,
+        "bodyFileName": "get_device_schedule_rules_response.json"
+    }
+}

--- a/tplinkcloud/device.py
+++ b/tplinkcloud/device.py
@@ -4,6 +4,7 @@ from .device_type import TPLinkDeviceType
 from .device_net_info import DeviceNetInfo
 from .device_time import DeviceTime
 from .device_timezone import DeviceTimezone
+from .device_schedule_rules import DeviceScheduleRules
 
 class TPLinkDevice:
 
@@ -109,7 +110,10 @@ class TPLinkDevice:
         return self._pass_through_request('set_led_off', 'off', led_off_state)
 
     def get_schedule_rules(self):
-        return self._pass_through_request('schedule', 'get_rules', {})
+        schedule_rules = self._pass_through_request('schedule', 'get_rules', {})
+        if schedule_rules is not None:
+            return DeviceScheduleRules(schedule_rules)
+        return None
 
     def edit_schedule_rule(self, rule):
         return self._pass_through_request('schedule', 'edit_rule', rule)

--- a/tplinkcloud/device_schedule_rules.py
+++ b/tplinkcloud/device_schedule_rules.py
@@ -1,0 +1,77 @@
+from enum import Enum
+
+class DeviceScheduleRuleStartOption(Enum):
+    Time = 0
+    Sunrise = 1
+    Sunset = 2
+
+class DeviceScheduleRule:
+    
+    def __init__(self, rule):
+        self.id = rule.get('id')
+        self.name = rule.get('name')
+        self.enable = rule.get('enable')
+        self.wday = rule.get('wday')
+        # Options are as follows:
+        #   0 - Start at a particular time
+        #   1 - Start at Sunrise
+        #   2 - Start at Sunset
+        self.stime_opt = rule.get('stime_opt')
+        self.soffset = rule.get('soffset')
+        # This is in minutes into the day
+        # There are 1440 minutes in a day
+        self.smin = rule.get('smin')
+        # If turning on the device, this will be 1
+        self.sact = rule.get('sact')
+        self.etime_opt = rule.get('etime_opt')
+        self.eoffset = rule.get('eoffset')
+        self.emin = rule.get('emin')
+        self.eact = rule.get('eact')
+        self.repeat = rule.get('repeat')
+        # The following three are specified when 'repeat' is not enabled
+        self.year = rule.get('year')
+        self.month = rule.get('month')
+        self.day = rule.get('day')
+
+        # Add in some custom "convenience" attributes
+        # These deviate from the raw information but add convenience
+        if self.enable is not None:
+            self.enabled = True if self.enable == 1 else False
+
+        if self.wday is not None and isinstance(self.wday, list) and len(self.wday) == 7:
+            self.sunday_enabled = True if self.wday[0] == 1 else False
+            self.monday_enabled = True if self.wday[1] == 1 else False
+            self.tuesday_enabled = True if self.wday[2] == 1 else False
+            self.wednesday_enabled = True if self.wday[3] == 1 else False
+            self.thursday_enabled = True if self.wday[4] == 1 else False
+            self.friday_enabled = True if self.wday[5] == 1 else False
+            self.saturday_enabled = True if self.wday[6] == 1 else False
+        
+        if self.stime_opt is not None:
+            self.start_type = DeviceScheduleRuleStartOption(self.stime_opt)
+
+        if self.sact is not None:
+            self.turn_on = True if self.sact == 1 else False
+            self.turn_off = not self.turn_on
+
+        if self.repeat is not None:
+            self.repeated = True if self.repeat == 1 else False
+        if self.smin is not None:
+            # Since year, month, day should be specified here, 
+            # create new time values based on `smin`
+            self.hour = self.smin // 60
+            self.minute = self.smin % 60
+
+
+class DeviceScheduleRules:
+    
+    def __init__(self, rules):
+        rule_list = rules.get('rule_list')
+        if rule_list:
+            self.rules = [DeviceScheduleRule(rule) for rule in rule_list]
+        else:
+            self.rules = []
+        self.version = rules.get('version')
+        self.enable = rules.get('enable')
+        self.err_code = rules.get('err_code')
+    


### PR DESCRIPTION
The existing method return schedule rules in their raw form. This creates classes around the schedule and rules and adds testing for the functionality.

Other functionality around a device's schedule is pending.

This is being created in response to this issue: https://github.com/piekstra/tplink-cloud-api/issues/21