### PR TITLE
v2.9.0 Add Rule Building

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,68 @@ if devices:
 
 These have the same functionality as the Smart Power Strips, though the HS103 and HS105 do not have the power usage features.
 
+## Add and modify schedule rules for your devices
+
+Edit an existing schedule rule
+
+```python
+from tplinkcloud import TPLinkDeviceManager, TPLinkDeviceScheduleRuleBuilder
+device_name = "My Smart Plug"
+device = device_manager.find_device(device_name)
+if device:
+  print(f'Found {device.model_type.name} device: {device.get_alias()}')
+  print(f'Modifying schedule rule')
+  schedule = device.get_schedule_rules()
+  original_rule = schedule.rules[0]
+  rule_edit = TPLinkDeviceScheduleRuleBuilder(
+    original_rule
+  ).with_enable_status(
+      False
+  )
+  device.edit_schedule_rule(rule_edit.to_json())
+else:  
+  print(f'Could not find {device_name}')
+```
+
+Add a new schedule rule
+
+```python
+from tplinkcloud import TPLinkDeviceManager, TPLinkDeviceScheduleRuleBuilder
+device_name = "My Smart Plug"
+device = device_manager.find_device(device_name)
+if device:
+  print(f'Found {device.model_type.name} device: {device.get_alias()}')
+  print(f'Adding schedule rule')
+  new_rule = TPLinkDeviceScheduleRuleBuilder(
+  ).with_action(
+      turn_on=True
+  ).with_name(
+      'My Schedule Rule'
+  ).with_enable_status(
+      True
+  ).with_sunset_start().with_repeat_on_days(
+      [0, 0, 0, 0, 0, 1, 1]
+  ).build()
+  device.add_schedule_rule(new_rule.to_json())
+else:  
+  print(f'Could not find {device_name}')
+```
+
+Delete a schedule rule
+
+```python
+from tplinkcloud import TPLinkDeviceManager, TPLinkDeviceScheduleRuleBuilder
+device_name = "My Smart Plug"
+device = device_manager.find_device(device_name)
+if device:
+  print(f'Found {device.model_type.name} device: {device.get_alias()}')
+  print(f'Deleting schedule rule')
+  schedule = device.get_schedule_rules()
+  rule = schedule.rules[0]
+  device.delete_schedule_rule(rule.id)
+else:  
+  print(f'Could not find {device_name}')
+
 ## Testing
 
 This project leverages `wiremock` to test the code to some extent. Note this will not protect the project from changes that TP-Link makes to their API, but instead verifies that the existing code functions consistently as written.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.8.1'
+__version__ = '2.9.0'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tplinkcloud/__init__.py
+++ b/tplinkcloud/__init__.py
@@ -1,7 +1,12 @@
 from .device_manager import TPLinkDeviceManager
 from .device_manager_power_tools import TPLinkDeviceManagerPowerTools
+from .device_schedule_rule_builder import TPLinkDeviceScheduleRuleBuilder
 
-__all__ = ['TPLinkDeviceManager', 'TPLinkDeviceManagerPowerTools', ]
+__all__ = [
+    'TPLinkDeviceManager',
+    'TPLinkDeviceManagerPowerTools',
+    'TPLinkDeviceScheduleRuleBuilder',
+]
 
 # Windows OS-specific HACK to silence exception thrown on event loop being closed
 # as part of the asyncio library's proactor

--- a/tplinkcloud/device.py
+++ b/tplinkcloud/device.py
@@ -115,8 +115,28 @@ class TPLinkDevice:
             return DeviceScheduleRules(schedule_rules)
         return None
 
+    def get_schedule_rule(self, rule_id):
+        schedule = self.get_schedule_rules()
+        if not schedule or not schedule.rules:
+            return None
+
+        for rule in schedule.rules:
+            if rule.id == rule_id:
+                return rule
+        
+        return None
+
     def edit_schedule_rule(self, rule):
         return self._pass_through_request('schedule', 'edit_rule', rule)
+        
+    def add_schedule_rule(self, rule):
+        return self._pass_through_request('schedule', 'add_rule', rule)
+
+    def delete_all_scheduled_rules(self):
+        return self._pass_through_request('schedule', 'delete_all_rules', None)
+
+    def delete_schedule_rule(self, rule_id):
+        return self._pass_through_request('schedule', 'delete_rule', {'id': rule_id})
 
     # Get SSID of network to which the device is connected
     def get_net_info(self):

--- a/tplinkcloud/device_schedule_rule_builder.py
+++ b/tplinkcloud/device_schedule_rule_builder.py
@@ -1,0 +1,137 @@
+from .device_schedule_rules import DeviceScheduleRule, DeviceScheduleRuleStartOption
+
+
+def buildermethod(func):
+  def wrapper(self, *args, **kwargs):
+    func(self, *args, **kwargs)
+    return self
+  return wrapper
+
+# Allows an existing rule class to be modified, or a new rule to be built
+# This should be used in combination with a device's edit or add schedule
+# rule functionality
+class TPLinkDeviceScheduleRuleBuilder:
+
+    def __init__(self, rule=None):
+        # Create an empty rule if non provided
+        if rule:
+            self._rule = rule
+        else:
+            self._rule = DeviceScheduleRule({})
+            # This is the default set by the Kasa app
+            self._rule.name = 'Schedule Rule'
+            # At this time it is best to leave these values as
+            # they are given that the Kasa app does not expose
+            # the ability to change them
+            self._rule.etime_opt = -1
+            self._rule.emin = 0
+            self._rule.eact = -1
+
+    @buildermethod
+    # Whether the device should be turned on or off
+    def with_action(self, turn_on):
+        self._rule.sact = 1 if turn_on else 0
+    
+    @buildermethod
+    # The name of the rule (not required and not currently visible via the app)
+    def with_name(self, name):
+        self._rule.name = name
+
+    @buildermethod
+    # Whether the rule should be enabled
+    def with_enable_status(self, enabled):
+        self._rule.enable = 1 if enabled else 0
+
+    @buildermethod
+    # What time of day the rule should trigger
+    # Overrides other time-of-day triggers
+    def with_time_start(self, time):
+        self._rule.stime_opt = DeviceScheduleRuleStartOption.Time.value
+        self._rule.smin = time.hour * 60 + time.minute
+
+    @buildermethod
+    # Set the rule to trigger at sunrise
+    # Overrides other time-of-day triggers
+    def with_sunrise_start(self):
+        self._rule.stime_opt = DeviceScheduleRuleStartOption.Sunrise.value
+
+    @buildermethod
+    # Set the rule to trigger at sunset
+    # Overrides other time-of-day triggers
+    def with_sunset_start(self):
+        self._rule.stime_opt = DeviceScheduleRuleStartOption.Sunset.value
+
+    @buildermethod
+    # days should be an array of 1's and 0's indicating whether to 
+    # apply the rule on a particular day
+    # Example:
+    #   [1, 1, 0, 0, 0, 0, 0]
+    # Means that the rule should be applied every Sunday and Monday
+    # Overrides one-run rules
+    def with_repeat_on_days(self, days):   
+        self._rule.repeat = 1     
+        self._rule.wday = days
+
+    @buildermethod
+    # What one-day should the rule run (the app only allows current/next day)
+    # Overrides repeat days
+    def with_one_run(self, time):
+        self._rule.repeat = 0
+        self._rule.wday = [0, 0, 0, 0, 0, 0, 0]
+        self._rule.year = time.year
+        self._rule.month = time.month
+        self._rule.day = time.day
+
+    @buildermethod
+    # This actually doesn't do anything other than validate the
+    # state of the rule being built. This is important when adding
+    # a new rule
+    def build(self):
+        if self._rule.name is None:
+            raise RuntimeError('Rule name is required')
+        if self._rule.sact is None:
+            raise RuntimeError('Rule action (sact) is required')
+        if self._rule.enable is None:
+            raise RuntimeError('Rule enable status is required')
+        if self._rule.repeat is None:
+            raise RuntimeError('Rule repeat status is required')
+        if self._rule.wday is None:
+            raise RuntimeError('Rule repeat days (wday) is required')
+
+    # These are the values expected and returned by the TP-Link API
+    # Not all values are required
+    def to_json(self):
+        obj_json = {}
+        if self._rule.id is not None:
+            obj_json['id'] = self._rule.id
+        if self._rule.name is not None:
+            obj_json['name'] = self._rule.name
+        if self._rule.enable is not None:
+            obj_json['enable'] = self._rule.enable
+        if self._rule.wday is not None:
+            obj_json['wday'] = self._rule.wday
+        if self._rule.stime_opt is not None:
+            obj_json['stime_opt'] = self._rule.stime_opt
+        if self._rule.soffset is not None:
+            obj_json['soffset'] = self._rule.soffset
+        if self._rule.smin is not None:
+            obj_json['smin'] = self._rule.smin
+        if self._rule.sact is not None:
+            obj_json['sact'] = self._rule.sact
+        if self._rule.etime_opt is not None:
+            obj_json['etime_opt'] = self._rule.etime_opt
+        if self._rule.eoffset is not None:
+            obj_json['eoffset'] = self._rule.eoffset
+        if self._rule.emin is not None:
+            obj_json['emin'] = self._rule.emin
+        if self._rule.eact is not None:
+            obj_json['eact'] = self._rule.eact
+        if self._rule.repeat is not None:
+            obj_json['repeat'] = self._rule.repeat
+        if self._rule.year is not None:
+            obj_json['year'] = self._rule.year
+        if self._rule.month is not None:
+            obj_json['month'] = self._rule.month
+        if self._rule.day is not None:
+            obj_json['day'] = self._rule.day
+        return obj_json

--- a/tplinkcloud/device_schedule_rules.py
+++ b/tplinkcloud/device_schedule_rules.py
@@ -62,6 +62,26 @@ class DeviceScheduleRule:
             self.hour = self.smin // 60
             self.minute = self.smin % 60
 
+    # These are the values expected and returned by the TP-Link API
+    def to_json(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'enable': self.enable,
+            'wday': self.wday,
+            'stime_opt': self.stime_opt,
+            'soffset': self.soffset,
+            'smin': self.smin,
+            'sact': self.sact,
+            'etime_opt': self.etime_opt,
+            'eoffset': self.eoffset,
+            'emin': self.emin,
+            'eact': self.eact,
+            'repeat': self.repeat,
+            'year': self.year,
+            'month': self.month,
+            'day': self.day,
+        }
 
 class DeviceScheduleRules:
     


### PR DESCRIPTION
This change introduces a new class, TPLinkDeviceScheduleRuleBuilder to complement added methods exposing device functionality around rules for a device schedule. Rules can not be retrieved by their ID, new rules can be added, and existing rules can be deleted.

The existing functionality exposed to edit a rule is now more user friendly with the TPLinkDeviceScheduleRuleBuilder class which allows a rule to be built or modified . Examples of this are provided in the README.md

This is being created in response to this issue: https://github.com/piekstra/tplink-cloud-api/issues/21