### PR TITLE
Offline EMeter devices

### DIFF
--- a/tplinkcloud/emeter_device.py
+++ b/tplinkcloud/emeter_device.py
@@ -47,7 +47,7 @@ class TPLinkEMeterDevice(TPLinkDevice):
             'get_realtime', 
             None
         )
-        if realtime_data.get('err_code') == 0:
+        if realtime_data is not None and realtime_data.get('err_code') == 0:
             return CurrentPower(realtime_data)
         return None
 


### PR DESCRIPTION
I found an issue with reading power data from e-meter devices if the device is offline where an exception was thrown instead of null being returned which used to happen.

I haven't updated the other methods in this file but I suspect they experience the same error. I wasn't sure if you wanted to return None or an empty array in those cases.