### PR TITLE
v2.9.1 'Offline' power data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.9.0'
+__version__ = '2.9.1'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tplinkcloud/emeter_device.py
+++ b/tplinkcloud/emeter_device.py
@@ -64,7 +64,7 @@ class TPLinkEMeterDevice(TPLinkDevice):
             }
         )
         # If there is no data for the requested month, data will be None
-        if day_response_data.get('err_code') == 0:
+        if day_response_data and day_response_data.get('err_code') == 0:
             return [DayPowerSummary(day_data) for day_data in day_response_data['day_list']]
         return []
 
@@ -80,6 +80,6 @@ class TPLinkEMeterDevice(TPLinkDevice):
             }
         )
         # If there is no data for the requested year, data will be None
-        if month_response_data.get('err_code') == 0:
+        if month_response_data and month_response_data.get('err_code') == 0:
             return [MonthPowerSummary(month_data) for month_data in month_response_data['month_list']]
         return []


### PR DESCRIPTION
When a device is 'offline', the power usage will not be available and we would expect to return `None` rather than throwing an exception. This change ensures that is the case.