### PR TITLE
v2.10.0 Add device runtime capability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 requests==2.25.1
+# For async http requests
 aiohttp==3.7.4
+# For mocking datetime
+freezegun==1.1.0

--- a/tests/test_device_manager_power_tools.py
+++ b/tests/test_device_manager_power_tools.py
@@ -1,8 +1,8 @@
 import os
 import pytest
+from freezegun import freeze_time
 
 from tplinkcloud import TPLinkDeviceManager, TPLinkDeviceManagerPowerTools
-
 
 @pytest.fixture(scope='module')
 def power_tools():
@@ -16,7 +16,6 @@ def power_tools():
     return TPLinkDeviceManagerPowerTools(
         client
     )
-
 
 @pytest.mark.usefixtures('power_tools')
 class TestDeviceManagerPowerTools(object):
@@ -59,7 +58,8 @@ class TestDeviceManagerPowerTools(object):
             assert device_usage.data.total_wh > 0
             assert device_usage.data.voltage_mv > 0
 
-    def test_get_devices_power_usage_day_gets_usage(self, power_tools):
+    @freeze_time("2021-04-09")
+    def test_get_devices_power_usage_day_gets_usage(self, power_tools):        
         devices_like = 'plug'
         usage = power_tools.get_devices_power_usage_day(devices_like)
         
@@ -91,6 +91,7 @@ class TestDeviceManagerPowerTools(object):
                 assert data_item.month == month
                 assert data_item.year == 2021
 
+    @freeze_time("2021-04-09")
     def test_get_devices_power_usage_month_gets_usage(self, power_tools):
         devices_like = 'plug'
         usage = power_tools.get_devices_power_usage_month(devices_like)

--- a/tplinkcloud/device.py
+++ b/tplinkcloud/device.py
@@ -6,6 +6,23 @@ from .device_time import DeviceTime
 from .device_timezone import DeviceTimezone
 from .device_schedule_rules import DeviceScheduleRules
 
+class DayRuntimeSummary:
+
+    def __init__(self, day_data):
+        self.year = day_data.get('year')
+        self.month = day_data.get('month')
+        self.day = day_data.get('day')
+        # Time is in minutes
+        self.time = day_data.get('time')
+
+class MonthRuntimeSummary:
+
+    def __init__(self, day_data):
+        self.year = day_data.get('year')
+        self.month = day_data.get('month')
+        # Time is in minutes
+        self.minutes = day_data.get('time')
+
 class TPLinkDevice:
 
     def __init__(self, client, device_id, device_info, child_id=None):
@@ -136,7 +153,34 @@ class TPLinkDevice:
         return self._pass_through_request('schedule', 'delete_all_rules', None)
 
     def delete_schedule_rule(self, rule_id):
-        return self._pass_through_request('schedule', 'delete_rule', {'id': rule_id})
+        return self._pass_through_request('schedule', 'delete_rule', {'id': rule_id})      
+
+    def get_runtime_day(self, year, month):
+        day_response_data = self._pass_through_request(
+            'schedule', 
+            'get_daystat', 
+            {
+                'year': year,
+                'month': month
+            }
+        )
+        # If there is no data for the requested month, data will be None
+        if day_response_data and day_response_data.get('err_code') == 0:
+            return [DayRuntimeSummary(day_data) for day_data in day_response_data['day_list']]
+        return []
+
+    def get_runtime_month(self, year):
+        month_response_data = self._pass_through_request(
+            'schedule', 
+            'get_monthstat', 
+            {
+                'year': year
+            }
+        )
+        # If there is no data for the requested year, data will be None
+        if month_response_data and month_response_data.get('err_code') == 0:
+            return [MonthRuntimeSummary(month_data) for month_data in month_response_data['month_list']]
+        return []
 
     # Get SSID of network to which the device is connected
     def get_net_info(self):

--- a/tplinkcloud/device.py
+++ b/tplinkcloud/device.py
@@ -153,7 +153,7 @@ class TPLinkDevice:
         return self._pass_through_request('schedule', 'delete_all_rules', None)
 
     def delete_schedule_rule(self, rule_id):
-        return self._pass_through_request('schedule', 'delete_rule', {'id': rule_id})      
+        return self._pass_through_request('schedule', 'delete_rule', {'id': rule_id})
 
     def get_runtime_day(self, year, month):
         day_response_data = self._pass_through_request(


### PR DESCRIPTION
This change introduces two new methods for all devices, `get_runtime_day` and `get_runtime_month`.

With `get_runtime_day`, you will see all runtimes in minutes for the specified year and month (where data is available) and can use that to look at the current day's runtime since the current value is contained in that list under the current year, month, day.

Daily averages and total runtimes as seen in the Kasa app can be calculated based on the raw data.

For example, total runtime for the past 7 days would be calculated by summing `time` for each day starting from the previous day (not today) through 7 days before that and dividing by 60 to get a value in hours. Daily Average over that period would simply be that value divided by 7.

For the past 30 day's values, follow the same method but sum all of the `time` data available from the current month (excluding the current day) as well as the previous month (at most 30 days of data in total across months is retained by TP-Link and that includes the current day). Take the summed value and divide by 60 to convert the units to hours and that will be the Total Runtime as seen in the app. For the Daily Average of the past 30 days, divide by 29 instead of 30 and you should see the same value as the app (though the app either rounds or truncates the value to 1 decimal place).

This feature is being added by request for this issue: https://github.com/piekstra/tplink-cloud-api/issues/42