### PR TITLE
v2.10.1 HS100 no EMeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ else:
 
 Replace `My Smart Plug` with the alias you gave to your plug in the Kasa app (be sure to give a different alias to each device). Instead of `toggle()`, you can also use `power_on()` or `power_off()`.
 
-To retrieve power consumption data for one of the individual plugs on the power strip:
+To retrieve power consumption data for one of the individual plugs on an HS300 power strip (KP303 does not support power usage data):
 
 ```python
 import json
@@ -107,7 +107,7 @@ if devices:
 
 ### Smart Plugs (Not Power Strips) (HS100, HS103, HS105, HS110, KP115)
 
-These have the same functionality as the Smart Power Strips, though the HS103 and HS105 do not have the power usage features.
+These have the same functionality as the Smart Power Strips, though the HS100, HS103 and HS105 do not have the power usage features.
 
 ## Add and modify schedule rules for your devices
 
@@ -170,6 +170,7 @@ if device:
   device.delete_schedule_rule(rule.id)
 else:  
   print(f'Could not find {device_name}')
+```
 
 ## Testing
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.10.0'
+__version__ = '2.10.1'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tplinkcloud/hs100.py
+++ b/tplinkcloud/hs100.py
@@ -1,6 +1,5 @@
 from tplinkcloud.device import TPLinkDevice
 from .device_type import TPLinkDeviceType
-from .emeter_device import TPLinkEMeterDevice
 
 
 class HS100Action:

--- a/tplinkcloud/hs100.py
+++ b/tplinkcloud/hs100.py
@@ -1,4 +1,4 @@
-from tplinkcloud.device import TPLinkDevice
+from .device import TPLinkDevice
 from .device_type import TPLinkDeviceType
 
 

--- a/tplinkcloud/hs100.py
+++ b/tplinkcloud/hs100.py
@@ -1,3 +1,4 @@
+from tplinkcloud.device import TPLinkDevice
 from .device_type import TPLinkDeviceType
 from .emeter_device import TPLinkEMeterDevice
 
@@ -35,7 +36,7 @@ class HS100SysInfo:
         self.longitude = sys_info.get('longitude')
 
 
-class HS100(TPLinkEMeterDevice):
+class HS100(TPLinkDevice):
 
     def __init__(self, client, device_id, device_info):
         super().__init__(client, device_id, device_info)

--- a/tplinkcloud/hs110.py
+++ b/tplinkcloud/hs110.py
@@ -1,14 +1,17 @@
+from tplinkcloud.emeter_device import TPLinkEMeterDevice
 from .device_type import TPLinkDeviceType
-from .hs100 import HS100, HS100SysInfo
+from .hs100 import HS100SysInfo
 
 
+# The HS110 is an updated version of the HS100 
+# that supports emeter capabilities
 class HS110SysInfo(HS100SysInfo):
 
     def __init__(self, sys_info):
         super().__init__(sys_info)
 
 
-class HS110(HS100):
+class HS110(TPLinkEMeterDevice):
 
     def __init__(self, client, device_id, device_info):
         super().__init__(client, device_id, device_info)

--- a/tplinkcloud/hs110.py
+++ b/tplinkcloud/hs110.py
@@ -1,4 +1,4 @@
-from tplinkcloud.emeter_device import TPLinkEMeterDevice
+from .emeter_device import TPLinkEMeterDevice
 from .device_type import TPLinkDeviceType
 from .hs100 import HS100SysInfo
 


### PR DESCRIPTION
The HS100 device does not have EMeter capabilities. This change aligns the library with that fact.

Small updates to the README were added to be more clear about the devices not supporting power usage data and also a fix to the block of code not being terminated.

This pull request is being created thanks to the following issue: https://github.com/piekstra/tplink-cloud-api/issues/45