### PR TITLE
v3.0.0 Separate Login Functionality

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.10.1'
+__version__ = '3.0.0'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -191,25 +191,14 @@ class TestFindDevices(object):
         assert devices is not None
         assert len(devices) == 2
 
+
 @pytest.mark.usefixtures('client')
 class TestAuth(object):
 
     def test_auth_no_username(self, client):
         with pytest.raises(ValueError):
-            TPLinkDeviceManager(
+            device_manager = TPLinkDeviceManager(
                 username=None,
-                password=os.environ.get('TPLINK_KASA_PASSWORD'),
-                prefetch=False,
-                cache_devices=False,
-                tplink_cloud_api_host=os.environ.get('TPLINK_KASA_API_URL'),
-                verbose=False,
-                term_id=os.environ.get('TPLINK_KASA_TERM_ID')
-            )
-
-    def test_auth_no_password(self, client):
-        with pytest.raises(ValueError):
-            TPLinkDeviceManager(
-                username=os.environ.get('TPLINK_KASA_USERNAME'),
                 password=None,
                 prefetch=False,
                 cache_devices=False,
@@ -217,3 +206,17 @@ class TestAuth(object):
                 verbose=False,
                 term_id=os.environ.get('TPLINK_KASA_TERM_ID')
             )
+            device_manager.login(None, os.environ.get('TPLINK_KASA_PASSWORD'))
+
+    def test_auth_no_password(self, client):
+        with pytest.raises(ValueError):
+            device_manager = TPLinkDeviceManager(
+                username=None,
+                password=None,
+                prefetch=False,
+                cache_devices=False,
+                tplink_cloud_api_host=os.environ.get('TPLINK_KASA_API_URL'),
+                verbose=False,
+                term_id=os.environ.get('TPLINK_KASA_TERM_ID')
+            )
+            device_manager.login(os.environ.get('TPLINK_KASA_USERNAME'), None)

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -195,6 +195,19 @@ class TestFindDevices(object):
 @pytest.mark.usefixtures('client')
 class TestAuth(object):
 
+    def test_auth_no_username_or_password(self, client):
+        # Should not see an exception raised
+        device_manager = TPLinkDeviceManager(
+            username=None,
+            password=None,
+            prefetch=False,
+            cache_devices=False,
+            tplink_cloud_api_host=os.environ.get('TPLINK_KASA_API_URL'),
+            verbose=False,
+            term_id=os.environ.get('TPLINK_KASA_TERM_ID')
+        )
+        assert device_manager is not None
+
     def test_auth_no_username(self, client):
         with pytest.raises(ValueError):
             device_manager = TPLinkDeviceManager(

--- a/tplinkcloud/device_manager.py
+++ b/tplinkcloud/device_manager.py
@@ -100,6 +100,7 @@ class TPLinkDeviceManager:
         return auth_token
 
     def set_auth_token(self, auth_token):
+        # this token is used for all requests to the TP-Link API
         self._auth_token = auth_token
 
     def get_devices(self):

--- a/tplinkcloud/device_manager.py
+++ b/tplinkcloud/device_manager.py
@@ -101,6 +101,7 @@ class TPLinkDeviceManager:
 
     def set_auth_token(self, auth_token):
         # this token is used for all requests to the TP-Link API
+        # where authentication is required
         self._auth_token = auth_token
 
     def get_devices(self):

--- a/tplinkcloud/device_manager.py
+++ b/tplinkcloud/device_manager.py
@@ -93,7 +93,8 @@ class TPLinkDeviceManager:
             return TPLinkDevice(client, tplink_device_info.device_id, tplink_device_info)
 
     def login(self, username, password):
-        # We should only need to get this once
+        # Note that this token expires after some amount of time
+        # (Currently unkown what exactly that expiration time is)
         auth_token = self._tplink_api.login(username, password)
         self.set_auth_token(auth_token)
         return auth_token


### PR DESCRIPTION
The `TPLinkDeviceManager` can now be constructed without a username and password. In order for requests to work properly, either the new `login` function or `set_auth_token` will need to be called.

While this change should not realistically break any existing functionality, an error is no longer raised when providing a `None`-valued username or password to the `TPLinkDeviceManager` constructor meaning that code depending on that behavior _would_ be broken.

The intent behind this change is to allow a device manager to be constructed that is "light weight", meaning it is a simple class instance that will not do anything like login when constructed. This separation allows a shell instance to be constructed without knowledge of a username and password, and then an auth token to be set before making requests. This bypasses the need to "login" for uses of the manager that may only have an auth token at the time instead of a username and password.

What this allows for is a workflow wherein a user of the manager can explicitly login, and cache or store the resulting auth token for later use. Later, the auth token could be retrieved and set in the manager for requests, without needing the original username and password.