### PR TITLE
Widen requirement version restrictions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        'requests==2.25.1',
-        'aiohttp==3.7.4'
+        'requests>=2,<3',
+        'aiohttp>=3,<4'
     ],
     url='https://github.com/piekstra/tplink-cloud-api',
     python_requires='>=3.7',


### PR DESCRIPTION
It's not recommended to explicitly declare a dependency version unless absolutely required, and only major versions should break anything, the recommended way to restrict dependency versions is by their major version.

It also breaks compatibility with any other package that depends on the same dependencies, which in the case of `requests` is a lot.

https://packaging.python.org/discussions/install-requires-vs-requirements/
![image](https://user-images.githubusercontent.com/9505196/139641530-b3fbbb58-0054-443c-9dc9-db0f40841c3a.png)
