### PR TITLE
Add support for KP125 and fix missing async/await

### DIFF
--- a/tplinkcloud/device_manager.py
+++ b/tplinkcloud/device_manager.py
@@ -11,6 +11,7 @@ from .hs105 import HS105
 from .hs110 import HS110
 from .hs300 import HS300
 from .kp115 import KP115
+from .kp125 import KP125
 from .kp303 import KP303
 from .device import TPLinkDevice
 
@@ -95,6 +96,8 @@ class TPLinkDeviceManager:
             return HS300(client, tplink_device_info.device_id, tplink_device_info)
         elif tplink_device_info.device_model.startswith('KP115'):
             return KP115(client, tplink_device_info.device_id, tplink_device_info)
+        elif tplink_device_info.device_model.startswith('KP125'):
+            return KP125(client, tplink_device_info.device_id, tplink_device_info)
         elif tplink_device_info.device_model.startswith('KP303'):
             return KP303(client, tplink_device_info.device_id, tplink_device_info)
         else:

--- a/tplinkcloud/device_type.py
+++ b/tplinkcloud/device_type.py
@@ -9,6 +9,7 @@ class TPLinkDeviceType(Enum):
     HS300 = 300
     HS300CHILD = 3000
     KP115 = 115
+    KP125 = 125
     KP303 = 303
     KP303CHILD = 3030
     UNKNOWN = 9999

--- a/tplinkcloud/kp115.py
+++ b/tplinkcloud/kp115.py
@@ -14,8 +14,8 @@ class KP115(HS110):
         super().__init__(client, device_id, device_info)
         self.model_type = TPLinkDeviceType.KP115
 
-    def get_sys_info(self):
-        sys_info = self._get_sys_info()
+    async def get_sys_info(self):
+        sys_info = await self._get_sys_info()
         
         if not sys_info:
             print("Something went wrong with your request; please try again")

--- a/tplinkcloud/kp125.py
+++ b/tplinkcloud/kp125.py
@@ -1,0 +1,24 @@
+from .device_type import TPLinkDeviceType
+from .hs110 import HS110, HS110SysInfo
+
+
+class KP125SysInfo(HS110SysInfo):
+
+    def __init__(self, sys_info):
+        super().__init__(sys_info)
+
+
+class KP125(HS110):
+
+    def __init__(self, client, device_id, device_info):
+        super().__init__(client, device_id, device_info)
+        self.model_type = TPLinkDeviceType.KP125
+
+    async def get_sys_info(self):
+        sys_info = await self._get_sys_info()
+        
+        if not sys_info:
+            print("Something went wrong with your request; please try again")
+            return None
+        
+        return KP125SysInfo(sys_info)


### PR DESCRIPTION
As the title says, the PR adds KP125 support: https://www.kasasmart.com/us/products/smart-plugs/kasa-smart-plug-slim-energy-monitoring-kp125

I based the KP125 support on KP115 -- this is a guess based on 1. model numbers, and 2. the KP115 and KP125 both have an emeter. If there are some API details that I have missed, please let me know.