### PR TITLE
v4.1.1 Normalize EMeter Data 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '4.1.0'
+__version__ = '4.1.1'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()

--- a/tplinkcloud/emeter_device.py
+++ b/tplinkcloud/emeter_device.py
@@ -1,15 +1,30 @@
 import asyncio
 
 from .device import TPLinkDevice
+from .device_type import TPLinkDeviceType
 
 
 class CurrentPower:
 
     def __init__(self, realtime_data):
+        # The HS110 does not have the unit type suffixes, and others
+        # also may not but have yet to be identified. We attempt to
+        # normalize the results by trying both possible keys
         self.voltage_mv = realtime_data.get('voltage_mv')
+        if self.voltage_mv is None:
+            self.voltage_mv = realtime_data.get('voltage')
+
         self.current_ma = realtime_data.get('current_ma')
+        if self.current_ma is None:
+            self.current_ma = realtime_data.get('current')
+
         self.power_mw = realtime_data.get('power_mw')
+        if self.power_mw is None:
+            self.power_mw = realtime_data.get('power')
+
         self.total_wh = realtime_data.get('total_wh')
+        if self.total_wh is None:
+            self.total_wh = realtime_data.get('total')
 
 
 class DayPowerSummary:
@@ -18,7 +33,12 @@ class DayPowerSummary:
         self.year = day_data.get('year')
         self.month = day_data.get('month')
         self.day = day_data.get('day')
+        # The HS110 does not have the unit type suffixes, and others
+        # also may not but have yet to be identified. We attempt to
+        # normalize the results by trying both possible keys
         self.energy_wh = day_data.get('energy_wh')
+        if self.energy_wh is None:
+            self.energy_wh = day_data.get('energy')
 
 
 class MonthPowerSummary:
@@ -26,25 +46,31 @@ class MonthPowerSummary:
     def __init__(self, day_data):
         self.year = day_data.get('year')
         self.month = day_data.get('month')
+        # The HS110 does not have the unit type suffixes, and others
+        # also may not but have yet to be identified. We attempt to
+        # normalize the results by trying both possible keys
         self.energy_wh = day_data.get('energy_wh')
+        if self.energy_wh is None:
+            self.energy_wh = day_data.get('energy')
 
 
 class TPLinkEMeterDevice(TPLinkDevice):
 
     def __init__(self, client, device_id, device_info, child_id=None):
         super().__init__(client, device_id, device_info, child_id)
-    
+
     # This is an override for regular devices
     def has_emeter(self):
         return True
 
     async def get_power_usage_realtime(self):
         realtime_data = await self._pass_through_request(
-            'emeter', 
-            'get_realtime', 
+            'emeter',
+            'get_realtime',
             None
         )
         if realtime_data is not None and realtime_data.get('err_code') == 0:
+            print(f"Found: {realtime_data}")
             return CurrentPower(realtime_data)
         return None
 
@@ -59,6 +85,7 @@ class TPLinkEMeterDevice(TPLinkDevice):
         )
         # If there is no data for the requested month, data will be None
         if day_response_data and day_response_data.get('err_code') == 0:
+            print(f"Day response: {day_response_data}")
             return [DayPowerSummary(day_data) for day_data in day_response_data['day_list']]
         return []
 
@@ -72,5 +99,6 @@ class TPLinkEMeterDevice(TPLinkDevice):
         )
         # If there is no data for the requested year, data will be None
         if month_response_data and month_response_data.get('err_code') == 0:
+            print(f"Month response: {month_response_data}")
             return [MonthPowerSummary(month_data) for month_data in month_response_data['month_list']]
         return []


### PR DESCRIPTION
Per https://github.com/piekstra/tplink-cloud-api/issues/51, the `HS110` device seems to be the only EMeter device supported by this library that can have a different response for the request to get emeter data from the Kasa API. Rather than having a unit-type suffix like `_wh` (watt hours), the response just has `energy` or `total`.

This change handles emeter data normalization by ensuring that the same contracts (class properties) are maintained by the library while accounting for the deviation in results from the Kasa API.

This resolves https://github.com/piekstra/tplink-cloud-api/issues/51