### PR TITLE
Add if 'next_action' exists check

### DIFF
--- a/tplinkcloud/hs105.py
+++ b/tplinkcloud/hs105.py
@@ -32,7 +32,8 @@ class HS105SysInfo:
         self.fw_id = sys_info.get('fwId')
         self.device_id = sys_info.get('deviceId')
         self.oem_id = sys_info.get('oemId')
-        self.next_action = HS105Action(sys_info.get('next_action'))
+        if 'next_action' in sys_info.keys():
+            self.next_action = HS105Action(sys_info.get('next_action'))
         self.err_code = sys_info.get('err_code')
 
 


### PR DESCRIPTION
Prevents `AttributeError: 'NoneType' object has no attribute 'get'` if 'next_action' isn't defined, which occurs when running the example `fetch_all_devices_sys_info()`, on a HS105 Plug.