### PR TITLE
Fix AttributeError when creating TPLinkDeviceManager without credentials

### DIFF
--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -217,6 +217,26 @@ class TestAuth(object):
         assert device_manager is not None
 
     @pytest.mark.asyncio
+    async def test_auth_token_initialized_without_credentials(self, client):
+        # Regression test for issue #75
+        # When creating a device manager without credentials, _auth_token should
+        # still be initialized to None to avoid AttributeError
+        device_manager = TPLinkDeviceManager(
+            username=None,
+            password=None,
+            prefetch=True,  # This is the default that triggered the bug
+            cache_devices=True,
+            tplink_cloud_api_host=os.environ.get('TPLINK_KASA_API_URL'),
+            verbose=False,
+            term_id=os.environ.get('TPLINK_KASA_TERM_ID')
+        )
+        # Should be able to access _auth_token without AttributeError
+        assert device_manager._auth_token is None
+        # Should be able to set auth token manually
+        device_manager.set_auth_token('test_token')
+        assert device_manager._auth_token == 'test_token'
+
+    @pytest.mark.asyncio
     async def test_auth_no_username(self, client):
         with pytest.raises(ValueError):
             device_manager = await TPLinkDeviceManager(

--- a/tplinkcloud/device_manager.py
+++ b/tplinkcloud/device_manager.py
@@ -33,6 +33,7 @@ class TPLinkDeviceManager:
         self._cache_devices = cache_devices
         self._cached_devices = None
         self._term_id = term_id
+        self._auth_token = None
 
         self._tplink_api = TPLinkApi(
             tplink_cloud_api_host, verbose=self._verbose, term_id=self._term_id)


### PR DESCRIPTION
## [#75]

## Summary
- Initialize `_auth_token` to `None` in `__init__` to prevent `AttributeError` when accessing the attribute before `login()` is called
- Add regression test to verify the fix

## Problem
When creating a `TPLinkDeviceManager` without credentials (to set auth token later via `set_auth_token()`), an `AttributeError` is raised because `_auth_token` is never initialized.

This is a valid use case for users who want to cache their auth tokens to avoid API rate limits (see issue discussion).

## Test plan
- [x] Added unit test that verifies `_auth_token` is accessible and settable without credentials
- [x] All auth tests pass locally

## CI Note
This PR should be rebased after #80 is merged to get CI passing.