### PR TITLE
Handle responseData as both string and dict

### DIFF
--- a/tests/test_device_client.py
+++ b/tests/test_device_client.py
@@ -1,0 +1,78 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tplinkcloud.device_client import TPLinkDeviceClient
+
+
+class TestPassThroughRequest:
+
+    @pytest.mark.asyncio
+    async def test_pass_through_request_handles_string_response_data(self):
+        """Test that string responseData is parsed as JSON"""
+        client = TPLinkDeviceClient(
+            host='http://test.example.com',
+            token='test_token'
+        )
+
+        mock_response = MagicMock()
+        mock_response.successful = True
+        mock_response.result = {
+            'responseData': '{"system": {"get_sysinfo": {"relay_state": 1}}}'
+        }
+
+        with patch.object(client, '_request_post', new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            result = await client.pass_through_request(
+                'device123',
+                {'system': {'get_sysinfo': {}}}
+            )
+
+        assert result == {'system': {'get_sysinfo': {'relay_state': 1}}}
+
+    @pytest.mark.asyncio
+    async def test_pass_through_request_handles_dict_response_data(self):
+        """
+        Test that dict responseData is returned as-is.
+        Some devices (e.g., Archer routers) return responseData as a dict
+        instead of a JSON string. Regression test for issue #65.
+        """
+        client = TPLinkDeviceClient(
+            host='http://test.example.com',
+            token='test_token'
+        )
+
+        mock_response = MagicMock()
+        mock_response.successful = True
+        # responseData is already a dict, not a JSON string
+        mock_response.result = {
+            'responseData': {'system': {'get_sysinfo': {'relay_state': 1}}}
+        }
+
+        with patch.object(client, '_request_post', new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            result = await client.pass_through_request(
+                'device123',
+                {'system': {'get_sysinfo': {}}}
+            )
+
+        assert result == {'system': {'get_sysinfo': {'relay_state': 1}}}
+
+    @pytest.mark.asyncio
+    async def test_pass_through_request_returns_none_on_failure(self):
+        """Test that None is returned when request fails"""
+        client = TPLinkDeviceClient(
+            host='http://test.example.com',
+            token='test_token'
+        )
+
+        mock_response = MagicMock()
+        mock_response.successful = False
+
+        with patch.object(client, '_request_post', new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            result = await client.pass_through_request(
+                'device123',
+                {'system': {'get_sysinfo': {}}}
+            )
+
+        assert result is None

--- a/tplinkcloud/device_client.py
+++ b/tplinkcloud/device_client.py
@@ -62,6 +62,11 @@ class TPLinkDeviceClient:
         }
         response = await self._request_post(body)
         if response.successful:
-            return json.loads(response.result.get('responseData'))
+            response_data = response.result.get('responseData')
+            # Some devices (e.g., Archer routers) return responseData as a dict
+            # while others return it as a JSON string
+            if isinstance(response_data, str):
+                return json.loads(response_data)
+            return response_data
 
         return None


### PR DESCRIPTION
## [#65]

## Summary
- Fix `TypeError` when devices return `responseData` as a dict instead of a JSON string
- Add unit tests for `pass_through_request` covering both cases

## Problem
Some devices (e.g., Archer A8 routers) return `responseData` as an already-parsed dict rather than a JSON string. The code was unconditionally calling `json.loads()` which fails with:
```
TypeError: the JSON object must be str, bytes or bytearray, not dict
```

## Solution
Check the type of `responseData` before attempting to parse it:
- If it's a string, parse it with `json.loads()`
- If it's already a dict, return it directly

## Test plan
- [x] Added unit tests covering both string and dict responseData cases
- [x] Added test for failed requests returning None
- [x] All new tests pass locally

## Note
This may not fully resolve Archer router support since the device commands may differ from smart plugs. However, this fix removes the immediate crash and allows further investigation.

## CI Note
This PR should be rebased after #80 is merged to get CI passing.